### PR TITLE
Move variable declarations from header to C file to fix build with GCC 10

### DIFF
--- a/src/game/prerender.c
+++ b/src/game/prerender.c
@@ -32,6 +32,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "../physics/bond.h"
 #include "../physics/particle.h"
 
+int numofobjectrenders;
+_objectrender objectrender[512];
+
 void setuprenderobjects(void)
   {
   int count,count2;

--- a/src/game/prerender.h
+++ b/src/game/prerender.h
@@ -45,7 +45,7 @@ typedef struct
   float alpha;
   } _objectrender;
 
-int numofobjectrenders;
-_objectrender objectrender[512];
+extern int numofobjectrenders;
+extern _objectrender objectrender[512];
 
 #endif /* GISH_GAME_PRERENDER_H */

--- a/src/sdl/file.c
+++ b/src/sdl/file.c
@@ -34,6 +34,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "../sdl/file.h"
 
+size_t (*fread2)(void *,size_t,size_t,FILE *);
+size_t (*fwrite2)(const void *,size_t,size_t,FILE *);
+
 int comparestrings(const void *arg1,const void *arg2)
   {
   return(strcmp(arg1,arg2));

--- a/src/sdl/file.h
+++ b/src/sdl/file.h
@@ -26,8 +26,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 int comparestrings(const void *arg1,const void *arg2);
 int checkfilespec(char *filespec,char *filename);
 void listfiles(char *path,char *filespec,char filelist[1024][32],int directories);
-size_t (*fread2)(void *,size_t,size_t,FILE *);
-size_t (*fwrite2)(const void *,size_t,size_t,FILE *);
+extern size_t (*fread2)(void *,size_t,size_t,FILE *);
+extern size_t (*fwrite2)(const void *,size_t,size_t,FILE *);
 size_t freadswap(void *ptr,size_t psize,size_t pnum,FILE *pfp);
 size_t fwriteswap(const void *ptr,size_t psize,size_t pnum,FILE *pfp);
 


### PR DESCRIPTION
Not using extern in the header will cause multiple definition errors by the linker.

See also: https://gcc.gnu.org/gcc-10/porting_to.html