### PR TITLE
SDL2 in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 Make sure CMake and the development libraries for SDL, OpenAL and Vorbis are installed. In Debian-based systems, you need to install the following packages:
 
-    cmake libsdl1.2-dev libopenal-dev libvorbis-dev
+    cmake libsdl2-dev libopenal-dev libvorbis-dev
 
 Then simply issue:
 


### PR DESCRIPTION
The project uses SDL2, so the readme should use that one instead of 1.2