### PR TITLE
add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1666610816,
+        "narHash": "sha256-q4F2VNe5bpxXOvp16DyLwE1SgNZMbNO29ZQJPIomedg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6107f97012a0c134c5848125b5aa1b149b76d2c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.stdenv.mkDerivation {
+            pname = "freegish";
+            version = "0.0.0";
+
+            src = ./.;
+
+            nativeBuildInputs = with pkgs; [
+              cmake
+            ];
+
+            buildInputs = with pkgs; [
+              SDL2
+              openal
+              libvorbis
+              libpng
+            ];
+
+            cmakeFlags = [ "-DINSTALL_FHS=ON" ];
+          };
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              stdenv.cc
+              cmake
+              SDL2
+              openal
+              libvorbis
+              libpng
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
Currently it isn't always obvious how to fetch which packages in order to build freegish. Nix provides a devShell feature where you can specify which packages should be available in the shell. This shell can be accessed using:

```console
$ cd freegish
$ nix develop
# A bash shell is started with all dependencies available.
$ 
```

With [direnv](https://direnv.net/) it is possible to automatically load the right environment variables in your shell upon cd-ing to the project directory. `.envrc` instructs direnv to use `flake.nix` to fetch the right environment. This allows `cd freegish` which will automatically make all dependencies available in the current shell. It will automatically unload the environment once cd-ing out of the project directory.

Lastly, this PR also provides a package definition for Nix, so that anyone can build a Nix package of freegish. It can be build using:

```console
$ cd freegish
$ nix build
```

Or install it in the user's profile/home:

```console
$ nix profile install
```

Without cloning the repository, people who have Nix installed can do:

```console
$ nix profile install github:freegish/freegish
```

Or even to build and run freegish without installation:

```console
$ nix run github:freegish/freegish
```

It is possible to do this from this PR (without clone/checkout) using:

```console
$ nix run github:bobvanderlinden/freegish/pr-nix-flake
```

More info: https://xeiaso.net/blog/nix-flakes-1-2022-02-21

Note that https://github.com/freegish/freegish/pull/13 is still needed to properly install freegish in cmake.