### PR TITLE
Use standard boolean type

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -35,6 +35,6 @@
 #define max(x1,x2) ((x1) > (x2) ? (x1):(x2))
 #endif
 
-typedef enum {FALSE = 0, TRUE = 1} bool;
+#include <stdbool.h>
 
 #endif /* GISH_CONFIG_H */

--- a/src/game/vsmode.c
+++ b/src/game/vsmode.c
@@ -49,7 +49,7 @@ void versusmodemenu(int versusnum)
   char filename[32];
   bool is4Player;
   char* gametypeName;
-  bool menuItemClicked = FALSE;
+  bool menuItemClicked = false;
 
   unlocked=0;
   for (count=0;count<6;count++)

--- a/src/video/texture.c
+++ b/src/video/texture.c
@@ -157,7 +157,7 @@ int loadtexturepng(const char *filename, unsigned int **rgba, int *width, int *h
 
 int loadtexturetga(const char *filename, unsigned int **rgba, int *width, int *height)
   {
-	bool isAlpha = FALSE;
+	bool isAlpha = false;
   int count,count2;
   int red,green,blue,alpha;
   unsigned char origin;
@@ -185,7 +185,7 @@ int loadtexturetga(const char *filename, unsigned int **rgba, int *width, int *h
   fread2(&origin,1,1,fp);
   origin=(origin>>4)&3;
 
-  isAlpha = FALSE;
+  isAlpha = false;
 
   for (count=0;count<tgaheader.imageheight;count++)
   for (count2=0;count2<tgaheader.imagewidth;count2++)
@@ -199,7 +199,7 @@ int loadtexturetga(const char *filename, unsigned int **rgba, int *width, int *h
       alpha=255;
 
     if (alpha!=255)
-      isAlpha = TRUE;
+      isAlpha = true;
 
     if (!bigendian)
       {
@@ -256,7 +256,7 @@ char * getextension(char *filename)
 bool hasextension(char *filename, const char *desiredextension)
 {
 	char * extension = getextension(filename);
-	return (extension != NULL && strcmp(extension, desiredextension) == 0) ? TRUE : FALSE;
+	return extension != NULL && strcmp(extension, desiredextension) == 0;
 }
 
 void changeextension(char *filename, const char *newextension)


### PR DESCRIPTION
In C23, bool is a new reserved keyword [1], which means that a custom enum cannot be named after it anymore. Replace it with a proper bool type, which fulfills the original purpose of this enum.

Because not all compilers support C23 yet, including MSVC and Apple Clang [2], include the compatibility header stdbool.h available since C99 so it builds fine in all platforms.

This change is especially relevant because GCC 15 defaults to C23, causing freegish to fail to build [3].

[1] https://gcc.gnu.org/gcc-15/porting_to.html#c23-new-keywords
[2] https://en.cppreference.com/w/c/compiler_support/23
[3] https://bugs.debian.org/1096653

---

I don't have a Windows box to test this PR against. I'm assuming it has reasonably recent compilers that support at least C99.  I've tested with both GCC 14 and GCC 15, and it builds fine.