### PR TITLE
Declare compatibility with CMake policies up to 4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.9)
+cmake_minimum_required(VERSION 2.9...4.1)
 
 project(FreeGish C)
 


### PR DESCRIPTION
CMake 4.0 removed old behavior of policies introduced until CMake 3.5 [1]. This means that projects relying on those such old behaviors no longer work with the latest versions of CMake. Because of that, it refuses to build any project whose minimum required policy version range doesn't contain any version greater or equal to 3.5, which is the case of freegish.

Given that freegish doesn't rely on any old or new behavior from existing policies [2], declare it as compatible with all policies up to the latest released version, 4.1, so that it builds once again with CMake >= 4.0.

This approach is preferred over bumping the minimum required version, as there is no actual dependency on CMake 3.5 policies. Any version handling the new or old behavior of policies above 2.9 should be fine.

[1] https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features
[2] https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html

---

As I've mentioned above (and in the commit message), I don't think any policy change in relevant for freegish. I don't have experience with other platforms though. So it would be nice if anyone double-checked that's really the case , including testing on Windows and MacOS. I've been able to successfully build with CMake 3.31.6 and 4.1.2 on Debian.